### PR TITLE
Django 4.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 By Lotterywest GoRillas Team
 
-Version: Use 1.1.4 for Django <=1.9, 2.x.x for Django >= 1.9, Latest supported django version is 3.1
+Version: Use 1.1.4 for Django <=1.9, 2.x.x for Django >= 1.9, Latest supported django version is 4.0
 
 This project aims to provide a dead simple way to integrate SAML2
 Authentication into your Django powered app. Try it now, and get rid of the

--- a/django_saml2_auth_lw/urls.py
+++ b/django_saml2_auth_lw/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import url
+from django.urls import path
 from . import views
 
 app_name = 'django_saml2_auth'
 
 urlpatterns = [
-    url(r'^acs/$', views.acs, name="acs"),
-    url(r'^welcome/$', views.welcome, name="welcome"),
-    url(r'^denied/$', views.denied, name="denied"),
+    path('acs', views.acs, name="acs"),
+    path('welcome', views.welcome, name="welcome"),
+    path('denied', views.denied, name="denied"),
 ]

--- a/django_saml2_auth_lw/views.py
+++ b/django_saml2_auth_lw/views.py
@@ -20,7 +20,7 @@ from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
 from django.template import TemplateDoesNotExist
 from django.http import HttpResponseRedirect
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 
 # default User or custom User. Now both will work.
 User = get_user_model()
@@ -254,9 +254,9 @@ def signin(r):
 
     # Only permit signin requests where the next_url is a safe URL
     if parse_version(get_version()) >= parse_version('2.0'):
-        url_ok = is_safe_url(next_url, None)
+        url_ok = url_has_allowed_host_and_scheme(next_url, None)
     else:
-        url_ok = is_safe_url(next_url)
+        url_ok = url_has_allowed_host_and_scheme(next_url)
 
     if not url_ok:
         return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,9 @@ setup(
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.10',
+        'Framework :: Django :: 3.2',
+        'Framework :: Django :: 4.0',
 
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
@@ -54,6 +57,10 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 
     keywords='Django SAML2 Authentication Made Easy, integrate with SAML2 SSO such as Okta easily',


### PR DESCRIPTION
django.conf.urls.url has been removed in favour of djang.urls.path
https://github.com/django/django/blob/3.2.10/django/conf/urls/__init__.py#L16

django.utils.http.is_safe_url has been removed in favour of django.utils.http.url_has_allowed_host_and_scheme
https://github.com/django/django/blob/3.2.10/django/utils/http.py#L330